### PR TITLE
Update Minecraft version dependency constraint

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,6 +18,6 @@
   "depends": {
     "fabricloader": ">=${loader_version}",
     "fabric": "*",
-    "minecraft": "~${minecraft_version}"
+    "minecraft": ">=${minecraft_version}"
   }
 }


### PR DESCRIPTION
It's generally a decent idea to only limit the minecraft version on the low end. It allows people to try out the mod with snapshots and newer versions, like in the current 1.21.9 - 1.21.10 instance.
You can still say that you release for a specific 1.21.9 version and if it doesn't work on anything else the users are attempting with, that's their problem.

But it also gives people the option to keep using the mod when there aren't any breaking changes